### PR TITLE
Refactored code for pykeepass version 4.0.4 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Note: unless you see the very last line (```Saving Keepass database``), your cha
 - The Keepass expiration date cannot be set as there is no distinct Enpass data type for it
 - Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export.
 - The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass, but it already exists), the code will attach the internal enpass UID to that field name.
+- If your Enpass database contains entries which use 'escaped' content (e.g `=\"`) as title information, `pykeepass`' underlying XML processor is likely going to choke. Please ensure to provide clean data sources.

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Note: unless you see the very last line (```Saving Keepass database``), your cha
 - This program assumes that there will be 0...1 "totp" entries in the Enpass entry. In case Enpass should ever support more than one TOTP setting per entry  (should never happen), only the very last entry survives in the Keepass target file.
 - As part of the conversion, all entries will lose their original creation date as it does not seem to be possible to set that value via pykeepass
 - The Keepass expiration date cannot be set as there is no distinct Enpass data type for it
-- Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export
+- Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export.
 - The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass but it already exists), the code will attach the innternal enpass UID to that field name.

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Note: unless you see the very last line (```Saving Keepass database``), your cha
 - As part of the conversion, all entries will lose their original creation date as it does not seem to be possible to set that value via pykeepass
 - The Keepass expiration date cannot be set as there is no distinct Enpass data type for it
 - Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export.
-- The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass but it already exists), the code will attach the innternal enpass UID to that field name.
+- The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass, but it already exists), the code will attach the internal enpass UID to that field name.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,3 @@ Note: unless you see the very last line (```Saving Keepass database``), your cha
 - The Keepass expiration date cannot be set as there is no distinct Enpass data type for it
 - Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export
 - The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass but it already exists), the code will attach the innternal enpass UUID to that field name.
-
-## Dependencies
-
-- [pykeepass](https://pypi.org/project/pykeepass/) version 4.0.2. If you install a later package version, OTP import will no longer work and the import is prone to crash. See [this web site](https://gitlab.gnome.org/World/secrets/-/issues/421) for details.

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Note: unless you see the very last line (```Saving Keepass database``), your cha
 - As part of the conversion, all entries will lose their original creation date as it does not seem to be possible to set that value via pykeepass
 - The Keepass expiration date cannot be set as there is no distinct Enpass data type for it
 - Enpass groups/sections within an enpass entry are NOT transferred to Keepass. Reason: they are exported as "empty" entries and apart from their order enumeration, there is no connection to the fields that are part of Enpass' export
-- The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass but it already exists), the code will attach the innternal enpass UUID to that field name.
+- The export process will always write NEW entries to Keepass. EXISTING entries will NOT be updated; if a key name conflict is detected (e.g. a key is to be written to Keepass but it already exists), the code will attach the innternal enpass UID to that field name.

--- a/enpasstokeepass.py
+++ b/enpasstokeepass.py
@@ -32,14 +32,24 @@ import base64
 import unicodedata
 import argparse
 
+pk_reserved_keys = []
+pk_reserved_special_keys = ["otp"]
+
+# get the list of reserved keys from pykeepass whereas
+# present. This is important if the user runs a pykeepass
+# version of 4.0.4 and later.
+#
+try:
+    from pykeepass.entry import reserved_keys as _pk_keys
+
+    pk_reserved_keys = _pk_keys.copy()
+except ImportError:
+    pass
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(module)s -%(levelname)s- %(message)s"
 )
 logger = logging.getLogger(__name__)
-
-# This program only runs with pykeepass version 4.0.2 so
-# let's ensure that the user has this version installed
-PYKEEPASS_VERSION_REQUIRED = "4.0.2"
 
 
 def read_enpass_json_file(json_filename: str):
@@ -85,24 +95,48 @@ def read_enpass_json_file(json_filename: str):
     return json_content
 
 
-def remove_control_characters(s):
+def remove_control_characters(s: str):
     """
     Removes Unicode control characters from the input string
     (those control characters would result in an import error)
+
+    Parameters
+    ==========
+    s : 'str'
+        our input string
+
+    Returns
+    =======
+    string without unicode control characters
     """
 
     return "".join(ch for ch in s if unicodedata.category(ch)[0] != "C")
 
 
-if __name__ == "__main__":
-    # check if the user has the correct pykeepass version installed
-    if pykeepass_version != PYKEEPASS_VERSION_REQUIRED:
-        logger.error(
-            msg=f"This program only runs with pykeepass version {PYKEEPASS_VERSION_REQUIRED}"
-        )
-        logger.error(msg=f"Your version of pykeepass is: {pykeepass_version}")
-        exit(0)
+def is_reserved_word(my_key: str):
+    """
+    Detects if the key that we are about to write is something
+    that is considered as "reserved key" by pykeepass
 
+    Parameters
+    ==========
+    my_key : 'str'
+        the key that we want to check
+
+    Returns
+    =======
+    'None" if not found, else pykeepass' reserved key
+    """
+
+    low_key = my_key.lower()
+    lower_reserved_values = [res.lower() for res in pk_reserved_keys]
+    if low_key in lower_reserved_values:
+        return pk_reserved_keys[lower_reserved_values.index(low_key)]
+    else:
+        return None
+
+
+if __name__ == "__main__":
     # Get our parameters
     # Syntax: enpasstokeepass <enpass_export_file> <keepass_target_file> [--password] [--keyfile]
     parser = argparse.ArgumentParser()
@@ -261,6 +295,15 @@ if __name__ == "__main__":
                                         f"Duplicate enpass label name '{mylabel}' for entry '{mytitle}' detected; attaching UID '{myuid}' to keepass label"
                                     )
                                     mylabel = f"{mylabel}_{myuid}"
+                                # now check if we deal with a reserved key. If applicable
+                                # AND the field is not of "otp" value, add the UID
+                                reserved_key = is_reserved_word(mylabel)
+                                if reserved_key:
+                                    if reserved_key not in pk_reserved_special_keys:
+                                        logger.info(
+                                            f"Detected reserved key '{mylabel}' for entry '{mytitle}'; attaching UID '{myuid}' to keepass label"
+                                        )
+                                        mylabel = f"{mylabel}_{myuid}"
 
                             # check if the label that we want to create contains a Keepass keyword
                             # (e.g. password, url). If yes, rename the field accordingly
@@ -357,9 +400,35 @@ if __name__ == "__main__":
                     )
                     # Add the extra properties (if present)
                     for value_field in value_fields:
-                        newentry.set_custom_property(
-                            key=value_field, value=value_fields[value_field]
-                        )
+                        # starting with pykeepass version 4.0.4, several attributes
+                        # need to be handled differently
+                        #
+                        # First check if the key that we are about to write is
+                        # a reserved word
+                        reserved_key = is_reserved_word(my_key=value_field)
+
+                        # No reserved key? Great - write entry as usual and "as is"
+                        if not reserved_key:
+                            newentry.set_custom_property(
+                                key=value_field, value=value_fields[value_field]
+                            )
+                        else:
+                            # We deal with a reserved key which requires us to invoke
+                            # the object's 'setter' method. HOWEVER: we can ONLY do
+                            # this for cases where our key is an 'otp' item - as updating
+                            # e.g. the 'title' item of the keepass entry that we are
+                            # about to create will not do - and is potentially not desired.
+                            if reserved_key in pk_reserved_special_keys:
+                                setattr(
+                                    newentry, reserved_key, value_fields[value_field]
+                                )
+                            else:
+                                # we deal with a reserved key but have already added a uuid to
+                                # the field. Set the value as is.
+                                newentry.set_custom_property(
+                                    key=value_field, value=value_fields[value_field]
+                                )
+
                     # write the attachments (if present)
                     if has_attachments:
                         attachments = myitem["attachments"]

--- a/enpasstokeepass.py
+++ b/enpasstokeepass.py
@@ -299,6 +299,8 @@ if __name__ == "__main__":
                                 # AND the field is not of "otp" value, add the UID
                                 reserved_key = is_reserved_word(mylabel)
                                 if reserved_key:
+                                    # now let's check if we need to keep the field 'as is'
+                                    # currently, this only applies to OTP entries
                                     if reserved_key not in pk_reserved_special_keys:
                                         logger.info(
                                             f"Detected reserved key '{mylabel}' for entry '{mytitle}'; attaching UID '{myuid}' to keepass label"
@@ -404,7 +406,9 @@ if __name__ == "__main__":
                         # need to be handled differently
                         #
                         # First check if the key that we are about to write is
-                        # a reserved word
+                        # a reserved word. Note that the only remaining
+                        # "reserved" key is an OTP entry - all other entries have
+                        # already been amended by their respective uid's
                         reserved_key = is_reserved_word(my_key=value_field)
 
                         # No reserved key? Great - write entry as usual and "as is"
@@ -414,19 +418,14 @@ if __name__ == "__main__":
                             )
                         else:
                             # We deal with a reserved key which requires us to invoke
-                            # the object's 'setter' method. HOWEVER: we can ONLY do
-                            # this for cases where our key is an 'otp' item - as updating
-                            # e.g. the 'title' item of the keepass entry that we are
-                            # about to create will not do - and is potentially not desired.
+                            # the object's 'setter' method. The ONLY entry that we should
+                            # see here is an "otp" entry. Every other reserved key has
+                            # already been force-amended with the field's uid value.
+                            # Nevertheless, let's keep this method generic in case of
+                            # future changes to pykeepass.
                             if reserved_key in pk_reserved_special_keys:
                                 setattr(
                                     newentry, reserved_key, value_fields[value_field]
-                                )
-                            else:
-                                # we deal with a reserved key but have already added a uuid to
-                                # the field. Set the value as is.
-                                newentry.set_custom_property(
-                                    key=value_field, value=value_fields[value_field]
                                 )
 
                     # write the attachments (if present)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pykeepass==4.0.2
+pykeepass


### PR DESCRIPTION
pykeepass 4.0.4 and later introduces 'reserved' fields such as 'title', 'otp' etc. Mainly, these are standard Enpass fields. However, if a user decided to use e.g. 'title' as part of their custom data, the previous program approach ceased to work, thus causing the program to crash.