### PR TITLE
UTF-8 Encoding and missing requirement

### DIFF
--- a/enpasstokeepass.py
+++ b/enpasstokeepass.py
@@ -76,7 +76,7 @@ def read_enpass_json_file(json_filename: str):
 
     if os.path.isfile(json_filename):
         try:
-            with open(f"{json_filename}", "r") as f:
+            with open(f"{json_filename}", "r", encoding="utf-8") as f:
                 if f.mode == "r":
                     list_lines = f.readlines()
                     f.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pykeepass
+pytz


### PR DESCRIPTION
I had to fix the encoding, because the enpass json is UTF-8 but python ignores this and messed up my german "Umlaute" (e.g. äöü). 
I was also missing the requirement pytz.